### PR TITLE
docs: expand release workflow and versioning process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,24 @@ make clean-all
 # 4. After changes: rebuild and click refresh icon on extension card
 ```
 
+## Release Process
+
+```bash
+# After committing your release changes on main:
+git push
+
+# Tag the current HEAD
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+
+# Push the tag to trigger the release workflow
+git push origin vX.Y.Z
+```
+
+The repository’s release workflow is configured to run on pushed tags matching `v*.*.*`, and it:
+1. validates `manifest.json` version matches the tag,
+2. builds `dist/sidekiq-queue-kill-switch.zip`,
+3. creates a GitHub release with that ZIP attached.
+
 ## Testing
 
 Manual testing only - navigate to a Sidekiq Enterprise queues page and verify:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,18 +113,20 @@ export VERSION="X.Y.Z"
 #    - Move items from [Unreleased] into [VERSION - YYYY-MM-DD] (or update/add directly)
 #    - Ensure the entry is complete and accurate
 
-# Bump manifest version
+# Bump release versions (manifest.json and package.json)
 python3 - <<'PY'
 import json, pathlib, os
-path = pathlib.Path("manifest.json")
-data = json.loads(path.read_text(encoding="utf-8"))
-data["version"] = os.environ["VERSION"]
-path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+target_version = os.environ["VERSION"]
+for filename in ("manifest.json", "package.json"):
+    path = pathlib.Path(filename)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["version"] = target_version
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 PY
 
 # Commit the version bump on main
-git add manifest.json
-git commit -m "chore(release): bump version to $VERSION"
+git add manifest.json package.json
+git commit -m "chore(release): bump versions to $VERSION"
 
 # Tag the current HEAD
 git tag -a "v$VERSION" -m "Release v$VERSION"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,14 +105,28 @@ make clean-all
 ## Release Process
 
 ```bash
-# After committing your release changes on main:
-git push
+# Set target release version
+export VERSION="X.Y.Z"
+
+# Bump manifest version
+python3 - <<'PY'
+import json, pathlib, os
+path = pathlib.Path("manifest.json")
+data = json.loads(path.read_text(encoding="utf-8"))
+data["version"] = os.environ["VERSION"]
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+
+# Commit the version bump on main
+git add manifest.json
+git commit -m "chore(release): bump version to $VERSION"
 
 # Tag the current HEAD
-git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git tag -a "v$VERSION" -m "Release v$VERSION"
 
 # Push the tag to trigger the release workflow
-git push origin vX.Y.Z
+git push
+git push origin "v$VERSION"
 ```
 
 The repository’s release workflow is configured to run on pushed tags matching `v*.*.*`, and it:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,11 @@ make clean-all
 # Set target release version
 export VERSION="X.Y.Z"
 
+# Update changelog
+# 1) Add release notes to CHANGELOG.md:
+#    - Move items from [Unreleased] into [VERSION - YYYY-MM-DD] (or update/add directly)
+#    - Ensure the entry is complete and accurate
+
 # Bump manifest version
 python3 - <<'PY'
 import json, pathlib, os


### PR DESCRIPTION
## Summary

This PR updates the project release documentation to fully define the release flow.

## Included commits

- `0c1f3951c0f5589ad85da79ee3d7c3062cb3c469` — docs: add release workflow from tag push
- `f3f7ffccfa2a2ee148c44762df2e18237cf3fc04` — docs: include manifest version bump in release steps
- `e6c00d650fabe68d7fb3e5c921511b637ab9aa6a` — docs: include changelog step in release process
- `9a8fc5209006d435385f3df54b6c592e6905bd6b` — docs: bump package and manifest versions in release flow

## What changed

- Added release process guidance in `AGENTS.md`.
- Required updating `CHANGELOG.md` before release.
- Standardized version bump to update both:
  - `manifest.json`
  - `package.json`
- Included the exact release execution sequence (tagging and push), matching the existing GitHub Release workflow trigger (`v*.*.*`).
