### PR TITLE
fix: preserve queue action forms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # CI workflow for Sidekiq Queue Kill Switch Chrome Extension
 #
 # Runs on PRs and pushes to main. Validates the extension structure,
-# runs sanity checks, and verifies the package builds successfully.
+# runs tests and sanity checks, and verifies the package builds successfully.
 
 name: CI
 
@@ -30,6 +30,9 @@ jobs:
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
         with:
           bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Validate manifest.json structure
         run: |
@@ -140,6 +143,9 @@ jobs:
             fi
           done
           echo "✓ All required icons exist"
+
+      - name: Run unit tests
+        run: bun test
 
       - name: Build extension package
         run: make package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ PY
 
 # Commit the version bump on main
 git add manifest.json package.json
-git commit -m "chore(release): bump versions to $VERSION"
+git commit -s -m "chore(release): bump versions to $VERSION"
 
 # Tag the current HEAD
 git tag -a "v$VERSION" -m "Release v$VERSION"
@@ -137,13 +137,19 @@ git push origin "v$VERSION"
 ```
 
 The repository’s release workflow is configured to run on pushed tags matching `v*.*.*`, and it:
-1. validates `manifest.json` version matches the tag,
+1. validates `manifest.json` and `package.json` versions match the tag,
 2. builds `dist/sidekiq-queue-kill-switch.zip`,
 3. creates a GitHub release with that ZIP attached.
 
 ## Testing
 
-Manual testing only - navigate to a Sidekiq Enterprise queues page and verify:
+Run automated coverage first:
+
+```bash
+bun test
+```
+
+Then manually navigate to a Sidekiq Enterprise queues page and verify:
 1. Controls appear near page header
 2. Confirmation dialogs work
 3. Status updates during operation
@@ -161,7 +167,7 @@ Manual testing only - navigate to a Sidekiq Enterprise queues page and verify:
 - Renovate runs for normal updates on demand, with a 3-day minimum release age, and immediate security updates.
 - Local checks used during this work:
   - `bun install`
-  - `bunx renovate-config-validator --strict .github/renovate.json`
+  - `bunx --package renovate renovate-config-validator --strict .github/renovate.json`
   - `bunx renovate --platform=github --token=$RENOVATE_TOKEN chenrui333/sidekiq-queue-kill-switch-chrome-extension --dry-run=full`
 - If Renovate stops creating branches, check for a stray `renovate/*` branch in the repository because Renovate requires branch names with this prefix.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-05-10
+
+### Fixed
+- Preserve pause/unpause actions when Sidekiq renders a separate delete-only form with the same queue action URL.
+- Count queues by unique Sidekiq queue action URL instead of raw form count.
+
+### Added
+- Bun/jsdom coverage for duplicate queue forms, safe fallback submit buttons, and delete-only forms.
+
+### Changed
+- Standardize repo agent guidance on `AGENTS.md` only.
+- Correct release and Renovate validation documentation.
+
 ## [1.5.2] - 2025-01-25
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -212,10 +212,11 @@ All console output is prefixed with `[SQKS]` for easy filtering:
 ### Making Changes
 
 1. Edit files in `src/`
-2. Run `make package` (or `bun run watch` for auto-rebuild)
-3. Go to `chrome://extensions/`
-4. Click the refresh icon on the extension card
-5. Reload the Sidekiq page to test
+2. Run `bun test`
+3. Run `make package` (or `bun run watch` for auto-rebuild)
+4. Go to `chrome://extensions/`
+5. Click the refresh icon on the extension card
+6. Reload the Sidekiq page to test
 
 ## Permissions
 
@@ -257,12 +258,12 @@ Releases are created automatically when you push a version tag.
 ### Quick Release
 
 ```bash
-# 1. Update version in manifest.json
-#    Edit manifest.json and change "version": "1.0.0" to "1.0.1"
+# 1. Update version in manifest.json and package.json
+#    Edit both files and change "version": "1.0.0" to "1.0.1"
 
 # 2. Commit the version bump
-git add manifest.json
-git commit -m "Bump version to 1.0.1"
+git add manifest.json package.json CHANGELOG.md
+git commit -s -m "chore(release): bump versions to 1.0.1"
 
 # 3. Create and push a matching tag
 git tag v1.0.1
@@ -272,7 +273,7 @@ git push origin main --tags
 ### What Happens
 
 1. GitHub Actions detects the `v*.*.*` tag push
-2. Validates that `manifest.json` version matches the tag (e.g., `v1.0.1` → `1.0.1`)
+2. Validates that `manifest.json` and `package.json` versions match the tag (e.g., `v1.0.1` -> `1.0.1`)
 3. Builds the extension ZIP using `make package`
 4. Creates a GitHub Release with auto-generated release notes
 5. Attaches `sidekiq-queue-kill-switch.zip` to the release
@@ -280,8 +281,8 @@ git push origin main --tags
 ### Version Matching Rules
 
 - Tag format: `v<major>.<minor>.<patch>` (e.g., `v1.0.1`, `v2.3.0`)
-- Manifest version: `<major>.<minor>.<patch>` (e.g., `1.0.1`, `2.3.0`)
-- The tag (minus the `v` prefix) must exactly match `manifest.json` version
+- Manifest and package version: `<major>.<minor>.<patch>` (e.g., `1.0.1`, `2.3.0`)
+- The tag (minus the `v` prefix) must exactly match both versions
 - Mismatches will fail the release with a clear error message
 
 ### Manual Release (Alternative)

--- a/bun.lock
+++ b/bun.lock
@@ -5,16 +5,41 @@
     "": {
       "name": "sidekiq-queue-kill-switch",
       "devDependencies": {
+        "jsdom": "^29.1.1",
         "vite": "^8.0.0",
       },
     },
   },
   "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.0", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -54,11 +79,27 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -84,7 +125,13 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -92,14 +139,44 @@
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "rolldown": ["rolldown@1.0.0-rc.18", "", { "dependencies": { "@oxc-project/types": "=0.128.0", "@rolldown/pluginutils": "1.0.0-rc.18" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.18", "@rolldown/binding-darwin-arm64": "1.0.0-rc.18", "@rolldown/binding-darwin-x64": "1.0.0-rc.18", "@rolldown/binding-freebsd-x64": "1.0.0-rc.18", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tldts": ["tldts@7.0.30", "", { "dependencies": { "tldts-core": "^7.0.30" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw=="],
+
+    "tldts-core": ["tldts-core@7.0.30", "", {}, "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidekiq Queue Kill Switch",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Adds Pause All / Unpause All controls to Sidekiq Enterprise Queues page for oncall use.",
   "icons": {
     "16": "icons/icon16.png",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
   "name": "sidekiq-queue-kill-switch",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "description": "Chrome Extension: Adds Pause All / Unpause All controls to Sidekiq Enterprise Queues page",
   "scripts": {
     "build": "vite build",
     "build:minify": "BUILD_MINIFY=1 vite build",
+    "test": "bun test",
     "watch": "vite build --watch",
     "assemble": "bun scripts/build-extension.mjs",
     "package": "bun run build && bun run assemble"
   },
   "devDependencies": {
+    "jsdom": "^29.1.1",
     "vite": "^8.0.0"
   },
   "engines": {

--- a/scripts/validate-version.py
+++ b/scripts/validate-version.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Validate that manifest.json version matches the expected version (from git tag).
+Validate that manifest.json and package.json versions match the expected version
+(from git tag).
 
 Usage:
     python3 scripts/validate-version.py <expected_version>
@@ -18,6 +19,31 @@ import sys
 import os
 
 
+def find_repo_file(filename):
+    paths = [
+        filename,
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), filename),
+    ]
+    for path in paths:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def load_json_file(filename):
+    path = find_repo_file(filename)
+    if not path:
+        print(f"::error::{filename} not found")
+        sys.exit(1)
+
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"::error::Failed to parse {filename}: {e}")
+        sys.exit(1)
+
+
 def main():
     if len(sys.argv) != 2:
         print(f"Usage: {sys.argv[0]} <expected_version>")
@@ -26,42 +52,26 @@ def main():
 
     expected_version = sys.argv[1]
 
-    # Find manifest.json relative to script or current directory
-    manifest_paths = [
-        "manifest.json",
-        os.path.join(os.path.dirname(os.path.dirname(__file__)), "manifest.json"),
-    ]
-
-    manifest_path = None
-    for path in manifest_paths:
-        if os.path.exists(path):
-            manifest_path = path
-            break
-
-    if not manifest_path:
-        print("::error::manifest.json not found")
-        sys.exit(1)
-
-    try:
-        with open(manifest_path, "r") as f:
-            manifest = json.load(f)
-    except json.JSONDecodeError as e:
-        print(f"::error::Failed to parse manifest.json: {e}")
-        sys.exit(1)
-
+    manifest = load_json_file("manifest.json")
+    package = load_json_file("package.json")
     manifest_version = manifest.get("version")
+    package_version = package.get("version")
 
     if not manifest_version:
         print("::error::No 'version' field found in manifest.json")
         sys.exit(1)
+    if not package_version:
+        print("::error::No 'version' field found in package.json")
+        sys.exit(1)
 
-    if manifest_version != expected_version:
+    if manifest_version != expected_version or package_version != expected_version:
         print("::error::Version mismatch!")
         print(f"  Tag version:      {expected_version}")
         print(f"  Manifest version: {manifest_version}")
+        print(f"  Package version:  {package_version}")
         print("")
-        print("To fix: Update manifest.json version to match your tag,")
-        print("        or create a tag that matches the manifest version.")
+        print("To fix: Update manifest.json and package.json versions to match your tag,")
+        print("        or create a tag that matches both versions.")
         sys.exit(1)
 
     print(f"✓ Version validated: {manifest_version}")

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -112,9 +112,43 @@
     perfMetrics = null;
   }
 
+  function createFormIndexEntry(actionPathKey, action) {
+    return {
+      forms: [],
+      form: null,
+      token: null,
+      pauseBtn: null,
+      unpauseBtn: null,
+      pauseForm: null,
+      unpauseForm: null,
+      pauseToken: null,
+      unpauseToken: null,
+      pauseAction: null,
+      unpauseAction: null,
+      hasDelete: false,
+      queueName: getQueueNameFromAction(action),
+      action,
+      actionPathKey,
+    };
+  }
+
+  function formHasDeleteControl(form) {
+    const candidates = form.querySelectorAll('input[type="submit"], button[type="submit"], button:not([type])');
+    for (const el of candidates) {
+      const name = (el.getAttribute('name') || '').trim().toLowerCase();
+      const value = (el.getAttribute('value') || '').trim().toLowerCase();
+      const text = (el.textContent || '').trim().toLowerCase();
+      if (name.includes('delete') || value.includes('delete') || text.includes('delete')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
-   * Build form index from a document for O(1) lookups
-   * Maps actionPathKey -> { form, token, pauseBtn, unpauseBtn }
+   * Build form index from a document for O(1) lookups.
+   * Multiple forms may share the same Sidekiq queue action URL, so aggregate
+   * the allowed action controls instead of letting a later delete-only form win.
    */
   function buildFormIndex(doc) {
     const start = PERF_ENABLED ? performance.now() : 0;
@@ -133,21 +167,39 @@
       if (!action) continue;
 
       const actionPathKey = normalizeActionPathKey(action);
+      let entry = index.get(actionPathKey);
+      if (!entry) {
+        entry = createFormIndexEntry(actionPathKey, action);
+        index.set(actionPathKey, entry);
+      }
+
       const tokenInput = form.querySelector('input[name="authenticity_token"]');
       const token = tokenInput ? tokenInput.value : null;
+      const pauseBtn = findSubmitButton(form, 'pause');
+      const unpauseBtn = findSubmitButton(form, 'unpause');
+      const hasDelete = formHasDeleteControl(form);
 
-      // Find both pause and unpause buttons for this form
-      const pauseBtn = form.querySelector('input[type="submit"][name="pause"], button[name="pause"]');
-      const unpauseBtn = form.querySelector('input[type="submit"][name="unpause"], button[name="unpause"]');
+      entry.forms.push({ form, token, pauseBtn, unpauseBtn, hasDelete, action });
+      entry.hasDelete = entry.hasDelete || hasDelete;
+      if (!entry.form || pauseBtn || unpauseBtn) {
+        entry.form = form;
+        entry.token = token;
+        entry.action = action;
+      }
 
-      index.set(actionPathKey, {
-        form,
-        token,
-        pauseBtn,
-        unpauseBtn,
-        queueName: getQueueNameFromAction(action),
-        action,
-      });
+      if (pauseBtn && !entry.pauseBtn) {
+        entry.pauseBtn = pauseBtn;
+        entry.pauseForm = form;
+        entry.pauseToken = token;
+        entry.pauseAction = action;
+      }
+
+      if (unpauseBtn && !entry.unpauseBtn) {
+        entry.unpauseBtn = unpauseBtn;
+        entry.unpauseForm = form;
+        entry.unpauseToken = token;
+        entry.unpauseAction = action;
+      }
     }
 
     perfMark('indexBuildTime', PERF_ENABLED ? performance.now() - start : 0);
@@ -228,7 +280,8 @@
     if (entry) {
       perfIncr('formIndexHits');
       const submitButton = actionType === 'pause' ? entry.pauseBtn : entry.unpauseBtn;
-      return { form: entry.form, submitButton };
+      const form = actionType === 'pause' ? entry.pauseForm : entry.unpauseForm;
+      return { form: form || entry.form, submitButton };
     }
 
     perfIncr('formIndexMisses');
@@ -713,14 +766,14 @@
     let formsNoToken = 0;
 
     for (const [actionPathKey, entry] of index) {
-      const { form, token, pauseBtn, unpauseBtn, queueName, action } = entry;
-      const submitButton = actionType === 'pause' ? pauseBtn : unpauseBtn;
+      const queueName = entry.queueName;
+      const submitButton = actionType === 'pause' ? entry.pauseBtn : entry.unpauseBtn;
+      const token = actionType === 'pause' ? entry.pauseToken : entry.unpauseToken;
+      const action = actionType === 'pause' ? entry.pauseAction : entry.unpauseAction;
 
       // If no submit button for this action, queue is already in desired state
       if (!submitButton) {
-        // Check if form has delete but no pause/unpause (for debugging)
-        const hasDelete = form.querySelector('input[name="delete"], button[name="delete"]');
-        if (hasDelete) {
+        if (entry.hasDelete) {
           formsWithDelete++;
         } else {
           formsNoMatchingAction++;
@@ -769,7 +822,7 @@
     }
 
     if (verbose) {
-      logVerbose(`Enumeration: ${index.size} total forms, ${actionable.length} actionable for "${actionType}"`);
+      logVerbose(`Enumeration: ${index.size} total queues, ${actionable.length} actionable for "${actionType}"`);
       logVerbose(`  - Already in desired state: ${formsNoMatchingAction}`);
       logVerbose(`  - Delete-only forms: ${formsWithDelete}`);
       logVerbose(`  - Missing token: ${formsNoToken}`);
@@ -1445,7 +1498,15 @@
   function getTotalQueueCount() {
     const table = document.querySelector('table.queues');
     if (!table) return 0;
-    return table.querySelectorAll('form[action*="/sidekiq/queues/"]').length;
+    const queueActionKeys = new Set();
+    const forms = table.querySelectorAll('form[action*="/sidekiq/queues/"]');
+    for (const form of forms) {
+      const action = form.getAttribute('action');
+      if (action) {
+        queueActionKeys.add(normalizeActionPathKey(action));
+      }
+    }
+    return queueActionKeys.size;
   }
 
   /**
@@ -1617,6 +1678,16 @@
     }
 
     log('Controls injected successfully');
+  }
+
+  if (typeof window !== 'undefined' && window.__SQKS_ENABLE_TEST_EXPORTS__) {
+    window.__SQKS_TEST__ = Object.freeze({
+      buildFormIndex,
+      findSubmitButton,
+      getActionableQueues,
+      getTotalQueueCount,
+      normalizeActionPathKey,
+    });
   }
 
   // Initialize

--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -1,0 +1,132 @@
+import { afterEach, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
+import { JSDOM } from 'jsdom';
+
+const CONTENT_SCRIPT_PATH = resolve('src/contentScript.js');
+const originalGlobals = {
+  console: globalThis.console,
+  confirm: globalThis.confirm,
+  document: globalThis.document,
+  DOMParser: globalThis.DOMParser,
+  performance: globalThis.performance,
+  window: globalThis.window,
+};
+
+function buildPage(queueForms) {
+  return `
+    <!doctype html>
+    <html>
+      <head><title>Queues</title></head>
+      <body>
+        <div class="header-container"><h1>Queues</h1></div>
+        <table class="queues"><tbody>${queueForms}</tbody></table>
+      </body>
+    </html>
+  `;
+}
+
+async function loadContentScript(html) {
+  const { window } = new JSDOM(html, {
+    url: 'https://example.test/sidekiq/queues',
+  });
+  window.__SQKS_ENABLE_TEST_EXPORTS__ = true;
+
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.DOMParser = window.DOMParser;
+  globalThis.confirm = () => true;
+  globalThis.console = {
+    ...originalGlobals.console,
+    log() {},
+    error() {},
+  };
+
+  const contentScriptSource = await Bun.file(CONTENT_SCRIPT_PATH).text();
+  new Function(contentScriptSource)();
+  return window.__SQKS_TEST__;
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(originalGlobals)) {
+    if (value === undefined) {
+      delete globalThis[key];
+    } else {
+      globalThis[key] = value;
+    }
+  }
+});
+
+test('keeps pause form actionable when a delete-only form shares the queue action URL', async () => {
+  const sqks = await loadContentScript(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="pause-token">
+          <input type="submit" name="pause" value="Pause">
+        </form>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="delete-token">
+          <input type="submit" name="delete" value="Delete">
+        </form>
+      </td>
+    </tr>
+  `));
+
+  const index = sqks.buildFormIndex(document);
+  const actionable = sqks.getActionableQueues(document, 'pause', false, index);
+
+  expect(index.size).toBe(1);
+  expect(actionable).toHaveLength(1);
+  expect(actionable[0]).toMatchObject({
+    action: '/sidekiq/queues/default',
+    formToken: 'pause-token',
+    queueName: 'default',
+    submitName: 'pause',
+    submitValue: 'Pause',
+  });
+  expect(sqks.getTotalQueueCount()).toBe(1);
+});
+
+test('indexes safe fallback submit buttons matched by value or text', async () => {
+  const sqks = await loadContentScript(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/mailers" method="post">
+          <input type="hidden" name="authenticity_token" value="fallback-token">
+          <button type="submit" name="commit" value="Pause">Pause</button>
+        </form>
+      </td>
+    </tr>
+  `));
+
+  const actionable = sqks.getActionableQueues(document, 'pause');
+
+  expect(actionable).toHaveLength(1);
+  expect(actionable[0]).toMatchObject({
+    action: '/sidekiq/queues/mailers',
+    formToken: 'fallback-token',
+    queueName: 'mailers',
+    submitName: 'commit',
+    submitValue: 'Pause',
+  });
+});
+
+test('does not treat delete-only forms as pause or unpause actions', async () => {
+  const sqks = await loadContentScript(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/danger" method="post">
+          <input type="hidden" name="authenticity_token" value="delete-token">
+          <button type="submit" name="delete" value="Delete">Delete</button>
+        </form>
+      </td>
+    </tr>
+  `));
+
+  const index = sqks.buildFormIndex(document);
+
+  expect(index.size).toBe(1);
+  expect(sqks.getActionableQueues(document, 'pause', false, index)).toEqual([]);
+  expect(sqks.getActionableQueues(document, 'unpause', false, index)).toEqual([]);
+  expect(sqks.getTotalQueueCount()).toBe(1);
+});


### PR DESCRIPTION
## Summary
- Preserve action-specific Sidekiq queue forms so delete-only duplicate forms cannot hide pause/unpause actions.
- Add Bun/jsdom coverage for duplicate forms, safe fallback submit buttons, and delete-only forms; run it in CI.
- Remove the `CLAUDE.md` forwarding file, update repo docs, and prepare the `1.5.3` patch release.

## Notes
After this merges, push tag `v1.5.3` to trigger the existing release workflow.
