### PR TITLE
fix: verify native submit outcomes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         run: bun test
 
       - name: Build extension package
-        run: make package
+        run: make package BUN_INSTALL_FLAGS=--frozen-lockfile
 
       - name: Verify built extension structure
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Release workflow for Sidekiq Queue Kill Switch Chrome Extension
 #
-# Triggered on version tags (v*.*.*). Validates manifest version matches tag,
-# builds the extension ZIP, and creates a GitHub Release with the asset attached.
+# Triggered on version tags (v*.*.*). Validates manifest and package versions
+# match the tag, builds the extension ZIP, and creates a GitHub Release with the asset attached.
 #
 # Uses softprops/action-gh-release for release creation because:
 # - Single action handles release creation + asset upload
@@ -44,12 +44,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION from tag: $TAG"
 
-      - name: Validate manifest version matches tag
+      - name: Validate package versions match tag
         run: |
           python3 scripts/validate-version.py "${{ steps.version.outputs.version }}"
 
       - name: Build extension package
-        run: make package
+        run: make package BUN_INSTALL_FLAGS=--frozen-lockfile
 
       - name: Verify ZIP was created
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-05-10
+
+### Fixed
+- Verify ambiguous native iframe submissions with a safe page refresh before retrying a queue action.
+- Skip token-refresh retries when the refreshed queues page already shows the target queue in the desired state.
+- Remove the Vite 8 ignored `inlineDynamicImports` warning from builds.
+
+### Changed
+- Use frozen Bun installs for CI and release package builds.
+- Update release workflow wording to reflect manifest and package version validation.
+
 ## [1.5.3] - 2026-05-10
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 .PHONY: all clean package build assemble install help
 
+BUN_INSTALL_FLAGS ?=
+
 # Default target
 all: package
 
 # Install dependencies
 install:
 	@echo "Installing dependencies with bun..."
-	@bun install
+	@bun install $(BUN_INSTALL_FLAGS)
 
 # Build with Vite
 build: install
@@ -58,6 +60,7 @@ help:
 	@echo "  make clean       - Remove build artifacts"
 	@echo "  make clean-all   - Remove build artifacts and node_modules"
 	@echo "  make help        - Show this help message"
+	@echo "  BUN_INSTALL_FLAGS=--frozen-lockfile - Pass install flags to bun"
 	@echo ""
 	@echo "Development:"
 	@echo "  bun run watch    - Watch mode for development"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidekiq Queue Kill Switch",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Adds Pause All / Unpause All controls to Sidekiq Enterprise Queues page for oncall use.",
   "icons": {
     "16": "icons/icon16.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidekiq-queue-kill-switch",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "type": "module",
   "description": "Chrome Extension: Adds Pause All / Unpause All controls to Sidekiq Enterprise Queues page",

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -741,7 +741,7 @@
       logError(`[${contextLabel}] GET non-OK status=${response.status}`);
     }
 
-    return { doc, htmlText: html, loginPage, status: response.status, ok: response.ok, responseHeaders, formIndex };
+    return { doc, htmlText: html, loginPage, hasQueuesTable, status: response.status, ok: response.ok, responseHeaders, formIndex };
   }
 
   /**
@@ -847,6 +847,69 @@
       map.set(q.actionPathKey, q);
     }
     return map;
+  }
+
+  function resolveFreshQueueAfterRefresh(queueInfo, freshDoc, actionType, formIndex = null, hasQueuesTable = true) {
+    if (!hasQueuesTable) {
+      return {
+        canTrust: false,
+        alreadyResolved: false,
+        fresh: null,
+        refreshedActionable: null,
+      };
+    }
+
+    const refreshedActionable = getActionableQueues(freshDoc, actionType, false, formIndex);
+    const fresh = refreshedActionable.find(q => q.actionPathKey === queueInfo.actionPathKey) || null;
+    return {
+      canTrust: true,
+      alreadyResolved: !fresh,
+      fresh,
+      refreshedActionable,
+    };
+  }
+
+  async function verifyQueueSettledAfterRefresh(queueInfo, actionType, contextLabel = 'native-verify') {
+    try {
+      const fetchResult = await fetchQueuesPageDocument(contextLabel);
+      if (fetchResult.loginPage) {
+        return {
+          checked: true,
+          ok: false,
+          loginPage: true,
+          diagKind: 'LOGIN',
+          freshDoc: fetchResult.doc,
+          fetchResult,
+        };
+      }
+
+      const refreshFormIndex = fetchResult.formIndex || (fetchResult.hasQueuesTable ? buildFormIndex(fetchResult.doc) : null);
+      const refreshed = resolveFreshQueueAfterRefresh(
+        queueInfo,
+        fetchResult.doc,
+        actionType,
+        refreshFormIndex,
+        fetchResult.hasQueuesTable
+      );
+
+      return {
+        checked: true,
+        ok: refreshed.canTrust && refreshed.alreadyResolved,
+        loginPage: false,
+        diagKind: refreshed.canTrust ? 'REFRESH_VERIFIED' : 'REFRESH_UNVERIFIED',
+        freshDoc: fetchResult.doc,
+        refreshed,
+        fetchResult,
+      };
+    } catch (error) {
+      return {
+        checked: false,
+        ok: false,
+        loginPage: false,
+        diagKind: 'REFRESH_FAILED',
+        error,
+      };
+    }
   }
 
   /**
@@ -1089,6 +1152,41 @@
           freshDoc: nativeRes.doc,
           freshDocSource: 'iframe',
         };
+      }
+      if (nativeRes.reason === 'loaded') {
+        const verified = await verifyQueueSettledAfterRefresh(queueInfo, effectiveActionType);
+        if (verified.loginPage) {
+          return {
+            ok: false,
+            status: 200,
+            is403: false,
+            bodySnippet: '',
+            loginPage: true,
+            diagKind: 'LOGIN',
+            hasQueuesTable: verified.fetchResult ? verified.fetchResult.hasQueuesTable : false,
+            freshDoc: verified.freshDoc,
+            freshDocSource: 'refresh',
+          };
+        }
+        if (verified.ok) {
+          logVerbose(`[native] verified ${queueName} reached desired state after refresh`);
+          return {
+            ok: true,
+            status: 200,
+            is403: false,
+            bodySnippet: '',
+            loginPage: false,
+            diagKind: 'REFRESH_VERIFIED',
+            hasQueuesTable: verified.fetchResult ? verified.fetchResult.hasQueuesTable : false,
+            freshDoc: verified.freshDoc,
+            freshDocSource: 'refresh',
+          };
+        }
+        if (verified.checked) {
+          logVerbose(`[native] refresh verification kept ${queueName} unresolved diag=${verified.diagKind}`);
+        } else {
+          logVerbose(`[native] refresh verification failed for ${queueName}:`, verified.error);
+        }
       }
       if (nativeRes.forbidden) {
         return {
@@ -1385,36 +1483,49 @@
                 // Build form index for fresh doc
                 const refreshFormIndex = fetchResult.formIndex || buildFormIndex(freshDoc);
 
-                // Retry this queue with fresh tokens (if still actionable)
-                const freshMap = buildQueueTokenMap(freshDoc, actionType, refreshFormIndex);
-                const fresh = freshMap.get(queueInfo.actionPathKey);
-                if (fresh) {
-                  queueInfo.formToken = fresh.formToken;
-                }
-                const retryResult = await submitQueueAction(queueInfo, csrfContext, actionType);
-                if (retryResult.ok) {
+                const refreshed = resolveFreshQueueAfterRefresh(
+                  queueInfo,
+                  freshDoc,
+                  actionType,
+                  refreshFormIndex,
+                  fetchResult.hasQueuesTable
+                );
+
+                if (refreshed.canTrust && refreshed.alreadyResolved) {
                   results.totalProcessed++;
-                  results.stats.retrySuccessCount++;
-                  logVerbose(`✓ ${actionType} ${queueInfo.queueName} (after token refresh)`);
+                  logVerbose(`✓ ${actionType} ${queueInfo.queueName} (already resolved after refresh)`);
                   alreadySucceededKeys.add(queueInfo.actionPathKey);
-                } else if (retryResult.is403 && (retryResult.loginPage || retryResult.diagKind === 'LOGIN')) {
-                  results.aborted = true;
-                  results.abortReason = 'Session expired / not authorized (login page detected after retry)';
-                  logError(results.abortReason);
-                  break;
                 } else {
-                  // Still failed after refresh - likely RBAC, not CSRF
-                  results.errors.push({
-                    queue: queueInfo.queueName,
-                    error: `HTTP ${retryResult.status} after token refresh (likely RBAC/permission)`,
-                    pass
-                  });
-                  logError(`Still failed after refresh: ${queueInfo.queueName} - HTTP ${retryResult.status}`);
+                  const fresh = refreshed.fresh;
+                  if (fresh) {
+                    queueInfo.formToken = fresh.formToken;
+                  }
+                  const retryResult = await submitQueueAction(queueInfo, csrfContext, actionType);
+                  if (retryResult.ok) {
+                    results.totalProcessed++;
+                    results.stats.retrySuccessCount++;
+                    logVerbose(`✓ ${actionType} ${queueInfo.queueName} (after token refresh)`);
+                    alreadySucceededKeys.add(queueInfo.actionPathKey);
+                  } else if (retryResult.is403 && (retryResult.loginPage || retryResult.diagKind === 'LOGIN')) {
+                    results.aborted = true;
+                    results.abortReason = 'Session expired / not authorized (login page detected after retry)';
+                    logError(results.abortReason);
+                    break;
+                  } else {
+                    // Still failed after refresh - likely RBAC, not CSRF
+                    results.errors.push({
+                      queue: queueInfo.queueName,
+                      error: `HTTP ${retryResult.status} after token refresh (likely RBAC/permission)`,
+                      pass
+                    });
+                    logError(`Still failed after refresh: ${queueInfo.queueName} - HTTP ${retryResult.status}`);
+                  }
                 }
 
                 // Rebuild actionable list after refresh to reduce drift (reuse form index)
-                actionable = getActionableQueues(freshDoc, actionType, false, refreshFormIndex)
-                  .filter(q => !alreadySucceededKeys.has(q.actionPathKey));
+                const refreshedActionable = refreshed.refreshedActionable
+                  || getActionableQueues(freshDoc, actionType, false, refreshFormIndex);
+                actionable = refreshedActionable.filter(q => !alreadySucceededKeys.has(q.actionPathKey));
                 invalidateFormIndexCache();
                 i = -1;
               } catch (refreshErr) {
@@ -1687,6 +1798,9 @@
       getActionableQueues,
       getTotalQueueCount,
       normalizeActionPathKey,
+      resolveFreshQueueAfterRefresh,
+      submitQueueAction,
+      verifyQueueSettledAfterRefresh,
     });
   }
 

--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -8,6 +8,7 @@ const originalGlobals = {
   confirm: globalThis.confirm,
   document: globalThis.document,
   DOMParser: globalThis.DOMParser,
+  fetch: globalThis.fetch,
   performance: globalThis.performance,
   window: globalThis.window,
 };
@@ -129,4 +130,144 @@ test('does not treat delete-only forms as pause or unpause actions', async () =>
   expect(sqks.getActionableQueues(document, 'pause', false, index)).toEqual([]);
   expect(sqks.getActionableQueues(document, 'unpause', false, index)).toEqual([]);
   expect(sqks.getTotalQueueCount()).toBe(1);
+});
+
+test('verifies an ambiguous native iframe load as success when refresh shows the queue resolved', async () => {
+  const sqks = await loadContentScript(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="pause-token">
+          <input type="submit" name="pause" value="Pause">
+        </form>
+      </td>
+    </tr>
+  `));
+
+  globalThis.fetch = async () => new Response(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="unpause-token">
+          <input type="submit" name="unpause" value="Unpause">
+        </form>
+      </td>
+    </tr>
+  `), {
+    headers: { 'content-type': 'text/html' },
+    status: 200,
+  });
+
+  const queueInfo = {
+    actionPathKey: '/sidekiq/queues/default',
+    queueName: 'default',
+  };
+  const result = await sqks.verifyQueueSettledAfterRefresh(queueInfo, 'pause', 'test-native-verify');
+
+  expect(result.ok).toBe(true);
+  expect(result.diagKind).toBe('REFRESH_VERIFIED');
+  expect(result.refreshed).toMatchObject({
+    canTrust: true,
+    alreadyResolved: true,
+  });
+});
+
+test('does not verify ambiguous native load when refresh still shows the action button', async () => {
+  const sqks = await loadContentScript(buildPage(''));
+  globalThis.fetch = async () => new Response(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="fresh-token">
+          <input type="submit" name="pause" value="Pause">
+        </form>
+      </td>
+    </tr>
+  `), {
+    headers: { 'content-type': 'text/html' },
+    status: 200,
+  });
+
+  const result = await sqks.verifyQueueSettledAfterRefresh({
+    actionPathKey: '/sidekiq/queues/default',
+    queueName: 'default',
+  }, 'pause', 'test-native-verify');
+
+  expect(result.ok).toBe(false);
+  expect(result.refreshed.canTrust).toBe(true);
+  expect(result.refreshed.alreadyResolved).toBe(false);
+  expect(result.refreshed.fresh).toMatchObject({
+    formToken: 'fresh-token',
+    submitName: 'pause',
+  });
+});
+
+test('does not skip retry decisions from an untrusted refresh document', async () => {
+  const sqks = await loadContentScript(buildPage(''));
+  const errorDoc = new DOMParser().parseFromString('<html><body>Service unavailable</body></html>', 'text/html');
+
+  const result = sqks.resolveFreshQueueAfterRefresh({
+    actionPathKey: '/sidekiq/queues/default',
+    queueName: 'default',
+  }, errorDoc, 'pause', null, false);
+
+  expect(result).toMatchObject({
+    canTrust: false,
+    alreadyResolved: false,
+    fresh: null,
+    refreshedActionable: null,
+  });
+});
+
+test('submitQueueAction accepts refresh-verified success after an ambiguous native iframe response', async () => {
+  const sqks = await loadContentScript(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="pause-token">
+          <input type="submit" name="pause" value="Pause">
+        </form>
+      </td>
+    </tr>
+  `));
+
+  document.querySelector('form').requestSubmit = () => {
+    const iframe = document.querySelector('iframe[name="sqks_target"]');
+    iframe.contentDocument.body.innerHTML = '<p>Forbidden without queues table</p>';
+    iframe.dispatchEvent(new window.Event('load'));
+  };
+
+  globalThis.fetch = async () => new Response(buildPage(`
+    <tr>
+      <td>
+        <form action="/sidekiq/queues/default" method="post">
+          <input type="hidden" name="authenticity_token" value="unpause-token">
+          <input type="submit" name="unpause" value="Unpause">
+        </form>
+      </td>
+    </tr>
+  `), {
+    headers: { 'content-type': 'text/html' },
+    status: 200,
+  });
+
+  const result = await sqks.submitQueueAction({
+    action: '/sidekiq/queues/default',
+    actionPathKey: '/sidekiq/queues/default',
+    actionType: 'pause',
+    formToken: 'pause-token',
+    queueName: 'default',
+    submitName: 'pause',
+    submitValue: 'Pause',
+  }, {
+    headerToken: null,
+    tokenSource: 'missing',
+  }, 'pause');
+
+  expect(result).toMatchObject({
+    ok: true,
+    status: 200,
+    diagKind: 'REFRESH_VERIFIED',
+    freshDocSource: 'refresh',
+  });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,13 +27,6 @@ export default defineConfig({
       fileName: () => 'contentScript.js',
     },
 
-    rollupOptions: {
-      output: {
-        // No code splitting for content scripts
-        inlineDynamicImports: true,
-      },
-    },
-
     // Generate sourcemaps for debugging (disabled in minified builds)
     sourcemap: !shouldMinify,
 


### PR DESCRIPTION
## Summary
- Verify ambiguous native iframe submissions with a safe refresh before retrying queue actions.
- Skip token-refresh retries when the refreshed queues page already shows the queue in the desired state.
- Prepare `1.5.4`, use frozen Bun installs for package builds in CI/release, and remove the Vite 8 ignored option warning.

## Notes
After this merges, push tag `v1.5.4` to trigger the release workflow.
