### PR TITLE
chore: add PR labeler and changelog release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,86 @@
+changed-files-labels-limit: 8
+
+bug:
+  - head-branch:
+      - '^fix/'
+
+dependencies:
+  - head-branch:
+      - '^renovate/'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'bun.lock'
+          - 'package.json'
+          - '.github/renovate.json'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+          - 'AGENTS.md'
+
+type:fix:
+  - head-branch:
+      - '^fix/'
+
+type:chore:
+  - head-branch:
+      - '^chore/'
+      - '^add-'
+      - '^update-'
+
+type:deps:
+  - head-branch:
+      - '^renovate/'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'bun.lock'
+          - 'package.json'
+          - '.github/renovate.json'
+
+type:docs:
+  - head-branch:
+      - '^docs/'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**'
+          - 'AGENTS.md'
+
+area:extension:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**'
+          - 'manifest.json'
+          - 'icons/**'
+
+area:build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Makefile'
+          - 'package.json'
+          - 'bun.lock'
+          - 'vite.config.js'
+          - 'scripts/bench-build.sh'
+          - 'scripts/build-extension.mjs'
+          - 'scripts/package.sh'
+
+area:ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+
+area:release:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'CHANGELOG.md'
+          - '.github/workflows/release.yml'
+          - 'scripts/extract-release-notes.py'
+          - 'scripts/validate-version.py'
+
+area:tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'test/**'
+          - '**/*.test.js'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,33 @@
+# Applies repository labels to pull requests based on branch names and changed files.
+# This workflow intentionally avoids checkout because pull_request_target has write access.
+
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  label:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@
 #
 # Uses softprops/action-gh-release for release creation because:
 # - Single action handles release creation + asset upload
-# - Native support for generate_release_notes
+# - Native support for changelog-derived release bodies via body_path
 # - Well-maintained and widely used
 # - Simpler than gh CLI for asset attachment
 
@@ -48,6 +48,10 @@ jobs:
         run: |
           python3 scripts/validate-version.py "${{ steps.version.outputs.version }}"
 
+      - name: Extract release notes
+        run: |
+          python3 scripts/extract-release-notes.py "${{ steps.version.outputs.version }}" "$RUNNER_TEMP/release-notes.md"
+
       - name: Build extension package
         run: make package BUN_INSTALL_FLAGS=--frozen-lockfile
 
@@ -72,7 +76,7 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           name: ${{ steps.version.outputs.tag }}
-          generate_release_notes: true
+          body_path: ${{ runner.temp }}/release-notes.md
           files: dist/sidekiq-queue-kill-switch.zip
           fail_on_unmatched_files: true
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,8 @@ for filename in ("manifest.json", "package.json"):
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 PY
 
-# Commit the version bump on main
-git add manifest.json package.json
+# Commit the version bump and release notes on main
+git add manifest.json package.json CHANGELOG.md
 git commit -s -m "chore(release): bump versions to $VERSION"
 
 # Tag the current HEAD
@@ -138,8 +138,9 @@ git push origin "v$VERSION"
 
 The repository’s release workflow is configured to run on pushed tags matching `v*.*.*`, and it:
 1. validates `manifest.json` and `package.json` versions match the tag,
-2. builds `dist/sidekiq-queue-kill-switch.zip`,
-3. creates a GitHub release with that ZIP attached.
+2. extracts release notes from `CHANGELOG.md`,
+3. builds `dist/sidekiq-queue-kill-switch.zip`,
+4. creates a GitHub release with that ZIP attached.
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bulk actions prefer native form submits before fetch/XHR fallback
 
+## [1.1.0] - 2025-01-24
+
+### Added
+- Native form submit mode with hidden iframe target for queue actions
+- HAR parser helper script for request pattern verification
+- Auto-download per-run diagnostics (logs + submission trace)
+
+### Changed
+- Bulk actions prefer native form submits before fetch/XHR fallback
+
 ## [1.0.9] - 2025-01-24
 
 ### Added
@@ -156,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Refresh strategy now rebuilds actionable queues in the same pass after token refresh
 - POST success classifier recognizes form-like 200 responses with queue table
+
 ## [1.0.8] - 2025-01-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ git add manifest.json package.json CHANGELOG.md
 git commit -s -m "chore(release): bump versions to 1.0.1"
 
 # 3. Create and push a matching tag
-git tag v1.0.1
-git push origin main --tags
+git tag -a v1.0.1 -m "Release v1.0.1"
+git push origin main
+git push origin v1.0.1
 ```
 
 ### What Happens
@@ -275,7 +276,7 @@ git push origin main --tags
 1. GitHub Actions detects the `v*.*.*` tag push
 2. Validates that `manifest.json` and `package.json` versions match the tag (e.g., `v1.0.1` -> `1.0.1`)
 3. Builds the extension ZIP using `make package`
-4. Creates a GitHub Release with auto-generated release notes
+4. Creates a GitHub Release with notes extracted from `CHANGELOG.md`
 5. Attaches `sidekiq-queue-kill-switch.zip` to the release
 
 ### Version Matching Rules

--- a/scripts/extract-release-notes.py
+++ b/scripts/extract-release-notes.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Extract a single version's release notes from CHANGELOG.md."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract release notes for VERSION from CHANGELOG.md."
+    )
+    parser.add_argument("version", help="Release version, with or without a leading v.")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="Optional output file. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--changelog",
+        default="CHANGELOG.md",
+        help="Path to the changelog file. Defaults to CHANGELOG.md.",
+    )
+    return parser.parse_args()
+
+
+def extract_release_notes(changelog: str, version: str) -> str:
+    normalized_version = version.removeprefix("v")
+    header_pattern = re.compile(
+        rf"^## \[{re.escape(normalized_version)}\](?:\s+-\s+[^\n]+)?\s*$",
+        re.MULTILINE,
+    )
+    match = header_pattern.search(changelog)
+    if not match:
+        raise ValueError(f"Could not find CHANGELOG.md section for {normalized_version}")
+
+    next_header = re.search(r"^## \[[^\]]+\].*$", changelog[match.end() :], re.MULTILINE)
+    end = match.end() + next_header.start() if next_header else len(changelog)
+    notes = changelog[match.end() : end].strip()
+    if not notes:
+        raise ValueError(f"CHANGELOG.md section for {normalized_version} is empty")
+
+    return notes + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    changelog_path = pathlib.Path(args.changelog)
+    changelog = changelog_path.read_text(encoding="utf-8")
+
+    try:
+        notes = extract_release_notes(changelog, args.version)
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        output_path = pathlib.Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(notes, encoding="utf-8")
+    else:
+        print(notes, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a pinned pull request labeler workflow and labeler config
- extract GitHub release notes from CHANGELOG.md instead of generated notes
- restore the missing v1.1.0 changelog section and align release docs

## Notes
- v1.5.4 was already tagged from the merged main commit.
- The initial labeler workflow will only run after this lands on main because it uses pull_request_target.
